### PR TITLE
Fix extension breaking for non-PNG avatars

### DIFF
--- a/pkg/avatar/decode.go
+++ b/pkg/avatar/decode.go
@@ -2,6 +2,8 @@ package avatar
 
 import (
 	"image"
+	_ "image/gif"
+	_ "image/jpeg"
 	_ "image/png"
 	"net/http"
 )


### PR DESCRIPTION
This registers GIF and JPEG is image formats that can be decoded.
